### PR TITLE
Adhere to latest go-ipfs API; use gx exclusively

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.0: QmbV34QGpZM44uEeu8N7Ppmv7Gx2Ev5UVeoo4np7mZbE8T
+0.0.1: QmYxnHPyYibhFw8jeZMhJrxXanKizezyNBW9AL1AwedC1A

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.1: QmYxnHPyYibhFw8jeZMhJrxXanKizezyNBW9AL1AwedC1A
+0.0.2: QmUDMGgMQuykb4883TugtGN4fWP1hUhc1uk3gSL2R5wgW9

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,0 +1,1 @@
+0.0.0: QmbV34QGpZM44uEeu8N7Ppmv7Gx2Ev5UVeoo4np7mZbE8T

--- a/add.go
+++ b/add.go
@@ -19,21 +19,16 @@ func (s *Shell) Add(r io.Reader) (string, error) {
 	if err != nil {
 		return "", errgo.Notef(err, "add: importing DAG failed.")
 	}
-	k, err := dag.Key()
-	if err != nil {
-		return "", errgo.Notef(err, "add: getting key from DAG failed.")
-	}
-	return k.B58String(), nil
+	return dag.Key().B58String(), nil
 }
 
 // AddLink creates a unixfs symlink and returns its hash
 func (s *Shell) AddLink(target string) (string, error) {
 	d, _ := ft.SymlinkData(target)
-	nd := &dag.Node{Data: d}
-	k, err := s.node.DAG.Add(nd)
+	nd := dag.NodeWithData(d)
+	c, err := s.node.DAG.Add(nd)
 	if err != nil {
 		return "", err
 	}
-
-	return k.B58String(), nil
+	return c.String(), nil
 }

--- a/add.go
+++ b/add.go
@@ -19,7 +19,7 @@ func (s *Shell) Add(r io.Reader) (string, error) {
 	if err != nil {
 		return "", errgo.Notef(err, "add: importing DAG failed.")
 	}
-	return dag.Key().B58String(), nil
+	return dag.Cid().String(), nil
 }
 
 // AddLink creates a unixfs symlink and returns its hash

--- a/cat.go
+++ b/cat.go
@@ -16,7 +16,7 @@ func (s *Shell) Cat(p string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, errgo.Notef(err, "cat: could not parse %q", p)
 	}
-	nd, err := core.Resolve(s.ctx, s.node, ipfsPath)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, ipfsPath)
 	if err != nil {
 		return nil, errgo.Notef(err, "cat: could not resolve %s", ipfsPath)
 	}

--- a/get.go
+++ b/get.go
@@ -1,9 +1,11 @@
 package embeddedShell
 
 import (
+	"errors"
 	"gopkg.in/errgo.v1"
 
 	"github.com/ipfs/go-ipfs/core"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/path"
 	tar "github.com/ipfs/go-ipfs/thirdparty/tar"
 	uarchive "github.com/ipfs/go-ipfs/unixfs/archive"
@@ -16,12 +18,17 @@ func (s *Shell) Get(ref, outdir string) error {
 		return errgo.Notef(err, "get: could not parse %q", ref)
 	}
 
-	nd, err := core.Resolve(s.ctx, s.node, ipfsPath)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, ipfsPath)
 	if err != nil {
 		return errgo.Notef(err, "get: could not resolve %s", ipfsPath)
 	}
 
-	r, err := uarchive.DagArchive(s.ctx, nd, outdir, s.node.DAG, false, 0)
+	pbnd, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return errors.New("could not cast Node to ProtoNode")
+	}
+
+	r, err := uarchive.DagArchive(s.ctx, pbnd, outdir, s.node.DAG, false, 0)
 	if err != nil {
 		return err
 	}

--- a/list.go
+++ b/list.go
@@ -42,10 +42,5 @@ func (s *Shell) ResolvePath(ipath string) (string, error) {
 		return "", err
 	}
 
-	k, err := nd.Key()
-	if err != nil {
-		return "", err
-	}
-
-	return k.B58String(), nil
+	return nd.Key().B58String(), nil
 }

--- a/list.go
+++ b/list.go
@@ -14,15 +14,15 @@ func (s *Shell) List(ipath string) ([]*sh.LsLink, error) {
 		return nil, err
 	}
 
-	nd, err := core.Resolve(s.ctx, s.node, p)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, p)
 	if err != nil {
 		return nil, err
 	}
 
 	var out []*sh.LsLink
-	for _, l := range nd.Links {
+	for _, l := range nd.Links() {
 		out = append(out, &sh.LsLink{
-			Hash: l.Hash.B58String(),
+			Hash: l.Cid.String(),
 			Name: l.Name,
 			Size: l.Size,
 		})
@@ -37,10 +37,10 @@ func (s *Shell) ResolvePath(ipath string) (string, error) {
 		return "", err
 	}
 
-	nd, err := core.Resolve(s.ctx, s.node, p)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, p)
 	if err != nil {
 		return "", err
 	}
 
-	return nd.Key().B58String(), nil
+	return nd.Cid().String(), nil
 }

--- a/object.go
+++ b/object.go
@@ -1,6 +1,7 @@
 package embeddedShell
 
 import (
+	"errors"
 	"fmt"
 
 	core "github.com/ipfs/go-ipfs/core"
@@ -11,7 +12,7 @@ import (
 )
 
 func (s *Shell) NewObject(template string) (string, error) {
-	node := new(dag.Node)
+	node := new(dag.ProtoNode)
 	switch template {
 	case "":
 		break
@@ -35,9 +36,14 @@ func (s *Shell) Patch(root, action string, args ...string) (string, error) {
 		return "", err
 	}
 
-	rootnd, err := core.Resolve(s.ctx, s.node, p)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, p)
 	if err != nil {
 		return "", err
+	}
+
+	rootnd, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return "", errors.New("could not cast Node to ProtoNode")
 	}
 
 	insertpath := args[0]
@@ -48,7 +54,7 @@ func (s *Shell) Patch(root, action string, args ...string) (string, error) {
 		return "", err
 	}
 
-	nnode, err := core.Resolve(s.ctx, s.node, childpath)
+	nnode, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, childpath)
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +73,7 @@ func (s *Shell) Patch(root, action string, args ...string) (string, error) {
 			return "", err
 		}
 
-		return e.GetNode().Key().B58String(), nil
+		return e.GetNode().Cid().String(), nil
 	default:
 		return "", fmt.Errorf("unsupported action (impl not complete)")
 	}
@@ -80,9 +86,14 @@ func (s *Shell) PatchLink(root, npath, childhash string, create bool) (string, e
 		return "", err
 	}
 
-	rootnd, err := core.Resolve(s.ctx, s.node, p)
+	nd, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, p)
 	if err != nil {
 		return "", err
+	}
+
+	rootnd, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return "", errors.New("could not cast Node to ProtoNode")
 	}
 
 	childpath, err := path.ParsePath(childhash)
@@ -90,13 +101,13 @@ func (s *Shell) PatchLink(root, npath, childhash string, create bool) (string, e
 		return "", err
 	}
 
-	nnode, err := core.Resolve(s.ctx, s.node, childpath)
+	nnode, err := core.Resolve(s.ctx, s.node.Namesys, s.node.Resolver, childpath)
 	if err != nil {
 		return "", err
 	}
 
 	e := dagutils.NewDagEditor(rootnd, s.node.DAG)
-	err = e.InsertNodeAtPath(s.ctx, npath, nnode, func() *dag.Node {
+	err = e.InsertNodeAtPath(s.ctx, npath, nnode, func() *dag.ProtoNode {
 		return dag.NodeWithData(ft.FolderPBData())
 	})
 	if err != nil {
@@ -108,5 +119,5 @@ func (s *Shell) PatchLink(root, npath, childhash string, create bool) (string, e
 		return "", err
 	}
 
-	return e.GetNode().Key().B58String(), nil
+	return e.GetNode().Cid().String(), nil
 }

--- a/object.go
+++ b/object.go
@@ -16,16 +16,16 @@ func (s *Shell) NewObject(template string) (string, error) {
 	case "":
 		break
 	case "unixfs-dir":
-		node.Data = ft.FolderPBData()
+		node.SetData(ft.FolderPBData())
 	default:
 		return "", fmt.Errorf("unknown template %s", template)
 	}
-	k, err := s.node.DAG.Add(node)
+	c, err := s.node.DAG.Add(node)
 	if err != nil {
 		return "", err
 	}
 
-	return k.B58String(), nil
+	return c.String(), nil
 }
 
 // TODO: extract all this logic from the core/commands/object.go to avoid dupe code
@@ -67,12 +67,7 @@ func (s *Shell) Patch(root, action string, args ...string) (string, error) {
 			return "", err
 		}
 
-		final, err := e.GetNode().Key()
-		if err != nil {
-			return "", err
-		}
-
-		return final.B58String(), nil
+		return e.GetNode().Key().B58String(), nil
 	default:
 		return "", fmt.Errorf("unsupported action (impl not complete)")
 	}
@@ -102,7 +97,7 @@ func (s *Shell) PatchLink(root, npath, childhash string, create bool) (string, e
 
 	e := dagutils.NewDagEditor(rootnd, s.node.DAG)
 	err = e.InsertNodeAtPath(s.ctx, npath, nnode, func() *dag.Node {
-		return &dag.Node{Data: ft.FolderPBData()}
+		return dag.NodeWithData(ft.FolderPBData())
 	})
 	if err != nil {
 		return "", err
@@ -113,10 +108,5 @@ func (s *Shell) PatchLink(root, npath, childhash string, create bool) (string, e
 		return "", err
 	}
 
-	final, err := e.GetNode().Key()
-	if err != nil {
-		return "", err
-	}
-
-	return final.B58String(), nil
+	return e.GetNode().Key().B58String(), nil
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "author": "noffle",
+  "author": "whyrusleeping",
   "bugs": {},
   "gx": {
-    "dvcsimport": "github.com/noffle/ipfs-embedded-shell"
+    "dvcsimport": "github.com/whyrusleeping/ipfs-embedded-shell"
   },
   "gxDependencies": [
     {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "author": "noffle",
+  "bugs": {},
+  "gx": {
+    "dvcsimport": "github.com/noffle/ipfs-embedded-shell"
+  },
+  "gxDependencies": [
+    {
+      "author": "whyrusleeping",
+      "hash": "QmfSc2xehWmWLnwwYR91Y8QF4xdASypTFVknutoKQS3GHp",
+      "name": "go-cid",
+      "version": "0.1.0"
+    }
+  ],
+  "gxVersion": "0.9.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "ipfs-embedded-shell",
+  "version": "0.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
       "hash": "QmfSc2xehWmWLnwwYR91Y8QF4xdASypTFVknutoKQS3GHp",
       "name": "go-cid",
       "version": "0.1.0"
+    },
+    {
+      "author": "ipfs",
+      "hash": "QmeUNjuZg7vSBPYHSF5VdSe9t3Y18g57ot2n6Wi3sJhtgN",
+      "name": "go-ipfs-api",
+      "version": "1.0.0"
     }
   ],
   "gxVersion": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "hash": "QmeUNjuZg7vSBPYHSF5VdSe9t3Y18g57ot2n6Wi3sJhtgN",
       "name": "go-ipfs-api",
       "version": "1.0.0"
+    },
+    {
+      "hash": "QmXEaqe2JNoSRHrHiBGJoaCG9Zn8WVzNdANzUNhruSBa86",
+      "name": "go-ipfs",
+      "version": "0.4.5-rc2"
     }
   ],
   "gxVersion": "0.9.0",
@@ -24,3 +29,4 @@
   "name": "ipfs-embedded-shell",
   "version": "0.0.1"
 }
+

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "language": "go",
   "license": "MIT",
   "name": "ipfs-embedded-shell",
-  "version": "0.0.0"
+  "version": "0.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "language": "go",
   "license": "MIT",
   "name": "ipfs-embedded-shell",
-  "version": "0.0.1"
+  "version": "0.0.2"
 }
 

--- a/shell_test.go
+++ b/shell_test.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs/assets"
-	"github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/mock"
 )
 
 type testShell struct {
-	key *key.Key
+	cid *cid.Cid
 	mn  *core.IpfsNode
 	s   *Shell
 }
@@ -31,7 +31,7 @@ func newTestShell(t *testing.T) *testShell {
 		t.Fatalf("assets.SeedInitDocs() failed: %s", err)
 	}
 	return &testShell{
-		key: tk,
+		cid: tk,
 		mn:  mn,
 		s:   NewShell(mn),
 	}
@@ -39,7 +39,7 @@ func newTestShell(t *testing.T) *testShell {
 
 func TestCat(t *testing.T) {
 	ts := newTestShell(t)
-	rc, err := ts.s.Cat(path.Join("/ipfs/", ts.key.String(), "about"))
+	rc, err := ts.s.Cat(path.Join("/ipfs/", ts.cid.String(), "about"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hey @whyrusleeping o/

I finally have this repo fully under gx for dependencies, and updated the go-ipfs API usage to match the changes over the last several months. This will make `ipget` very happy.